### PR TITLE
getBoxType import throws an error in OpenATV

### DIFF
--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -16,7 +16,11 @@ from Components.Sources.StaticText import StaticText
 from Plugins.Plugin import PluginDescriptor
 from Tools.Directories import resolveFilename, SCOPE_LANGUAGE, SCOPE_PLUGINS
 from os import environ
-from enigma import getDesktop, getBoxType
+from enigma import getDesktop
+try:
+    from enigma import getBoxType           # for OpenPLi and similar
+except ImportError:
+    from boxbranding import getBoxType      # for OpenATV and similar
 
 lang = language.getLanguage()
 environ["LANGUAGE"] = lang[:2]


### PR DESCRIPTION
OpenPLi or similar Enigma uses the `enigma` module, but OpenATV or similar Enigma uses the `boxbranding` module.

So, with OpenATV, an error occurs while importing a non-existent `getBoxType`.

Here is my original question for OpenATV developers: https://www.opena.tv/english-section/50844-question-oatv-developers-backupsuite-plugin-getboxtype.html#post428226